### PR TITLE
Expand inner macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -297,7 +297,7 @@ checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
 
 [[package]]
 name = "cainome"
-version = "0.2.3"
+version = "0.2.4-expand"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cainome"
-version = "0.2.3"
+version = "0.2.4-expand"
 edition = "2021"
 
 [workspace]
@@ -53,6 +53,7 @@ tokio = { version = "1.15.0", features = ["full"], optional = true }
 default = []
 abigen-rs = ["cainome-rs-macro"]
 build-binary = ["tokio"]
+expand-expr = ["cainome-rs-macro/expand-expr"]
 
 [[bin]]
 name = "cainome"

--- a/crates/rs-macro/Cargo.toml
+++ b/crates/rs-macro/Cargo.toml
@@ -17,3 +17,6 @@ syn = "2.0.15"
 serde_json = "1.0.74"
 thiserror.workspace = true
 cainome-cairo-serde.workspace = true
+
+[features]
+expand-expr = []

--- a/crates/rs-macro/src/expand_expr.rs
+++ b/crates/rs-macro/src/expand_expr.rs
@@ -1,0 +1,44 @@
+use proc_macro::TokenStream;
+use proc_macro2::{TokenStream as TokenStream2, TokenTree};
+use quote::ToTokens;
+use syn::{
+    parse::Result,
+    Expr, Lit, LitStr,
+};
+
+pub fn expand_to_literal(expr: Expr) -> Result<LitStr> {
+    let token_stream: TokenStream = expr.to_token_stream().into();
+    let abi_or_path_expr = token_stream.expand_expr().unwrap();
+
+    token_stream_as_lit_str(abi_or_path_expr)
+}
+
+
+fn token_stream_as_lit_str(input: TokenStream) -> Result<LitStr> {
+    let input: TokenStream2 = input.into();
+    let tokens: Vec<_> = input.into_iter().collect();
+    if tokens.len() != 1 {
+        return Err(syn::Error::new(
+            proc_macro2::Span::call_site(),
+            "Expected a single expression",
+        ));
+    }
+
+    match tokens[0].clone() {
+        TokenTree::Literal(lit) => {
+            let lit = Lit::new(lit);
+            if let Lit::Str(lit) = lit {
+                Ok(lit)
+            } else {
+                Err(syn::Error::new(
+                    lit.span(),
+                    "Expected an expresion that expands to a single string literal",
+                ))
+            }
+        }
+        _ => Err(syn::Error::new(
+            proc_macro2::Span::call_site(),
+            "Expected an expresion that expands to a single string literal",
+        )),
+    }
+}

--- a/crates/rs-macro/src/expand_expr.rs
+++ b/crates/rs-macro/src/expand_expr.rs
@@ -1,10 +1,7 @@
 use proc_macro::TokenStream;
 use proc_macro2::{TokenStream as TokenStream2, TokenTree};
 use quote::ToTokens;
-use syn::{
-    parse::Result,
-    Expr, Lit, LitStr,
-};
+use syn::{parse::Result, Expr, Lit, LitStr};
 
 pub fn expand_to_literal(expr: Expr) -> Result<LitStr> {
     let token_stream: TokenStream = expr.to_token_stream().into();
@@ -12,7 +9,6 @@ pub fn expand_to_literal(expr: Expr) -> Result<LitStr> {
 
     token_stream_as_lit_str(abi_or_path_expr)
 }
-
 
 fn token_stream_as_lit_str(input: TokenStream) -> Result<LitStr> {
     let input: TokenStream2 = input.into();

--- a/crates/rs-macro/src/lib.rs
+++ b/crates/rs-macro/src/lib.rs
@@ -1,11 +1,14 @@
+#![feature(proc_macro_expand)]
 use cainome_parser::{AbiParser, AbiParserLegacy};
-use cainome_rs::{self};
 use proc_macro::TokenStream;
 use quote::quote;
 
 mod macro_inputs;
 mod macro_inputs_legacy;
 mod spanned;
+
+#[cfg(feature = "expand-expr")]
+mod expand_expr;
 
 use crate::macro_inputs::ContractAbi;
 use crate::macro_inputs_legacy::ContractAbiLegacy;

--- a/crates/rs-macro/src/lib.rs
+++ b/crates/rs-macro/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(proc_macro_expand)]
+#![ cfg_attr( feature = "expand-expr", feature(proc_macro_expand) ) ]
 use cainome_parser::{AbiParser, AbiParserLegacy};
 use proc_macro::TokenStream;
 use quote::quote;

--- a/crates/rs-macro/src/macro_inputs.rs
+++ b/crates/rs-macro/src/macro_inputs.rs
@@ -43,14 +43,11 @@ impl Parse for ContractAbi {
 
         // let abi_or_path = input.parse::<LitStr>()?;
 
-        // ABI path or content.
-    
-
-
         // Expand the expression (specifically useful for include_str!(...))
         #[cfg(feature = "expand-expr")]
         let abi_or_path = crate::expand_expr::expand_to_literal(input.parse::<syn::Expr>()?)?;
 
+        // ABI path or content.
         #[cfg(not(feature = "expand-expr"))]
         let abi_or_path = input.parse::<LitStr>()?;
 
@@ -179,5 +176,3 @@ fn open_json_file(file_path: &str) -> Result<File> {
 pub fn str_to_litstr(str_in: &str) -> LitStr {
     LitStr::new(str_in, proc_macro::Span::call_site().into())
 }
-
-

--- a/crates/rs-macro/src/macro_inputs.rs
+++ b/crates/rs-macro/src/macro_inputs.rs
@@ -41,9 +41,17 @@ impl Parse for ContractAbi {
         let name = input.parse::<Ident>()?;
         input.parse::<Token![,]>()?;
 
-        // ABI path or content.
+        // let abi_or_path = input.parse::<LitStr>()?;
 
-        // Path rooted to the Cargo.toml location if it's a file.
+        // ABI path or content.
+    
+
+
+        // Expand the expression (specifically useful for include_str!(...))
+        #[cfg(feature = "expand-expr")]
+        let abi_or_path = crate::expand_expr::expand_to_literal(input.parse::<syn::Expr>()?)?;
+
+        #[cfg(not(feature = "expand-expr"))]
         let abi_or_path = input.parse::<LitStr>()?;
 
         #[allow(clippy::collapsible_else_if)]
@@ -171,3 +179,5 @@ fn open_json_file(file_path: &str) -> Result<File> {
 pub fn str_to_litstr(str_in: &str) -> LitStr {
     LitStr::new(str_in, proc_macro::Span::call_site().into())
 }
+
+

--- a/crates/rs-macro/src/spanned.rs
+++ b/crates/rs-macro/src/spanned.rs
@@ -29,6 +29,7 @@ impl<T: ParseInner> Parse for Spanned<T> {
 
 /// A struct that captures `Span` information for inner parsable data.
 #[cfg_attr(test, derive(Clone, Debug))]
+#[allow(dead_code)]
 pub struct Spanned<T>(Span, T);
 
 impl<T> Spanned<T> {


### PR DESCRIPTION
A draft PR to showcase the changes.

I've included an opt-in functionality to expand the expression which previously had to be Literal String. It allows for the abi to be included via the include_str!(...) macro. 

Due to the feature on which this mechanism depends being experimental, a nightly build of rust has to be used.  